### PR TITLE
Metadata fixes

### DIFF
--- a/items/d592_1.jsonld.json
+++ b/items/d592_1.jsonld.json
@@ -22,9 +22,6 @@
     "ark:/87293/d3h70851j",
     "AR-592, Box:1 Folder:1"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_10.jsonld.json
+++ b/items/d592_10.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_10.tif"
   },
-  "schema:description": "\"Daughters Josie Trafton, Annie Trafton, Agnes Trafton, Emily Trafton.\"",
+  "schema:description": "Daughters Josie Trafton, Annie Trafton, Agnes Trafton, Emily Trafton.",
   "schema:identifier": [
     "AR-592, Box:1 Folder:10",
     "ark:/87293/d3bg2hf9h"

--- a/items/d592_10.jsonld.json
+++ b/items/d592_10.jsonld.json
@@ -23,9 +23,6 @@
     "AR-592, Box:1 Folder:10",
     "ark:/87293/d3bg2hf9h"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_11.jsonld.json
+++ b/items/d592_11.jsonld.json
@@ -23,9 +23,6 @@
     "ark:/87293/d36t0h164",
     "AR-592, Box:1 Folder:11"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_11.jsonld.json
+++ b/items/d592_11.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_11.tif"
   },
-  "schema:description": "\"Sincerely - W.M. Trafton.\"",
+  "schema:description": "Sincerely - W.M. Trafton.",
   "schema:identifier": [
     "ark:/87293/d36t0h164",
     "AR-592, Box:1 Folder:11"

--- a/items/d592_12.jsonld.json
+++ b/items/d592_12.jsonld.json
@@ -23,9 +23,6 @@
     "AR-592, Box:1 Folder:12",
     "ark:/87293/d3319s72r"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_13.jsonld.json
+++ b/items/d592_13.jsonld.json
@@ -23,9 +23,6 @@
     "ark:/87293/d3z892k74",
     "AR-592, Box:1 Folder:13"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_13.jsonld.json
+++ b/items/d592_13.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_13.tif"
   },
-  "schema:description": "\"Son of James G. Trafton, Providence, R.I. [Rhode Island].\"",
+  "schema:description": "Son of James G. Trafton, Providence, R.I. [Rhode Island].",
   "schema:identifier": [
     "ark:/87293/d3z892k74",
     "AR-592, Box:1 Folder:13"

--- a/items/d592_14.jsonld.json
+++ b/items/d592_14.jsonld.json
@@ -22,9 +22,6 @@
     "ark:/87293/d3th8bs30",
     "AR-592, Box:1 Folder:14"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_15.jsonld.json
+++ b/items/d592_15.jsonld.json
@@ -22,9 +22,6 @@
     "ark:/87293/d3pr7mz97",
     "AR-592, Box:1 Folder:15"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_16.jsonld.json
+++ b/items/d592_16.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:16",
     "ark:/87293/d3k06x55t"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_17.jsonld.json
+++ b/items/d592_17.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:17",
     "ark:/87293/d3f766c2j"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_18.jsonld.json
+++ b/items/d592_18.jsonld.json
@@ -22,9 +22,6 @@
     "ark:/87293/d39k45z07",
     "AR-592, Box:1 Folder:18"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_19.jsonld.json
+++ b/items/d592_19.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:19",
     "ark:/87293/d35t3g46w"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_2.jsonld.json
+++ b/items/d592_2.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_2.tif"
   },
-  "schema:description": "\"Mother of Hattie Carpenter, whose funeral we attended.\"",
+  "schema:description": "Mother of Hattie Carpenter, whose funeral we attended.",
   "schema:identifier": [
     "ark:/87293/d3cf9jb77",
     "AR-592, Box:1 Folder:2"

--- a/items/d592_2.jsonld.json
+++ b/items/d592_2.jsonld.json
@@ -23,9 +23,6 @@
     "ark:/87293/d3cf9jb77",
     "AR-592, Box:1 Folder:2"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_21.jsonld.json
+++ b/items/d592_21.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:21",
     "ark:/87293/d3222rb22"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_22.jsonld.json
+++ b/items/d592_22.jsonld.json
@@ -22,9 +22,6 @@
     "ark:/87293/d3x921p7f",
     "AR-592, Box:1 Folder:22"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_23.jsonld.json
+++ b/items/d592_23.jsonld.json
@@ -23,9 +23,6 @@
     "AR-592, Box:1 Folder:23",
     "ark:/87293/d3sj19w4s"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_23.jsonld.json
+++ b/items/d592_23.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_23.tif"
   },
-  "schema:description": "Signed by \"Stewart\"",
+  "schema:description": "Signed by \"Stewart",
   "schema:identifier": [
     "AR-592, Box:1 Folder:23",
     "ark:/87293/d3sj19w4s"

--- a/items/d592_25.jsonld.json
+++ b/items/d592_25.jsonld.json
@@ -19,7 +19,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_25.tif"
   },
-  "schema:description": "\"Frank Sanches and wife. He contracted to pick all the fruit at $10.00 a ton.\"",
+  "schema:description": "Frank Sanches and wife. He contracted to pick all the fruit at $10.00 a ton.",
   "schema:identifier": [
     "AR-592, Box:1 Folder:25",
     "ark:/87293/d3ns0m302"

--- a/items/d592_25.jsonld.json
+++ b/items/d592_25.jsonld.json
@@ -24,9 +24,6 @@
     "AR-592, Box:1 Folder:25",
     "ark:/87293/d3ns0m302"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_26.jsonld.json
+++ b/items/d592_26.jsonld.json
@@ -23,9 +23,6 @@
     "AR-592, Box:1 Folder:26",
     "ark:/87293/d3j09w87j"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_27.jsonld.json
+++ b/items/d592_27.jsonld.json
@@ -23,9 +23,6 @@
     "AR-592, Box:1 Folder:27",
     "ark:/87293/d3db7vv57"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_28.jsonld.json
+++ b/items/d592_28.jsonld.json
@@ -19,7 +19,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_28.tif"
   },
-  "schema:description": "\"Antonio Caldrone, Beatrice Cook, Madge Cummings, Francis Moore, Ada Cummings, Celia Cook, Ponco Caldrone, Shedman. Same as pole puller in the hops.\"",
+  "schema:description": "Antonio Caldrone, Beatrice Cook, Madge Cummings, Francis Moore, Ada Cummings, Celia Cook, Ponco Caldrone, Shedman. Same as pole puller in the hops.",
   "schema:identifier": [
     "ark:/87293/d38k7521w",
     "AR-592, Box:1 Folder:28"

--- a/items/d592_28.jsonld.json
+++ b/items/d592_28.jsonld.json
@@ -24,9 +24,6 @@
     "ark:/87293/d38k7521w",
     "AR-592, Box:1 Folder:28"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_29.jsonld.json
+++ b/items/d592_29.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:29",
     "ark:/87293/d34t6f774"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_3.jsonld.json
+++ b/items/d592_3.jsonld.json
@@ -23,9 +23,6 @@
     "AR-592, Box:1 Folder:3",
     "ark:/87293/d37p8tj4k"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_3.jsonld.json
+++ b/items/d592_3.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_3.tif"
   },
-  "schema:description": "\"Children: Walter Trafton, Alice Trafton, Palmer Trafton, Frank Trafton, Lizzie Trafton\"",
+  "schema:description": "Children: Walter Trafton, Alice Trafton, Palmer Trafton, Frank Trafton, Lizzie Trafton",
   "schema:identifier": [
     "AR-592, Box:1 Folder:3",
     "ark:/87293/d37p8tj4k"

--- a/items/d592_30.jsonld.json
+++ b/items/d592_30.jsonld.json
@@ -22,9 +22,6 @@
     "ark:/87293/d3125qf39",
     "AR-592, Box:1 Folder:30"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_31.jsonld.json
+++ b/items/d592_31.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:31",
     "ark:/87293/d3w950s8p"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_32.jsonld.json
+++ b/items/d592_32.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:32",
     "ark:/87293/d3rj4905f"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_33.jsonld.json
+++ b/items/d592_33.jsonld.json
@@ -22,9 +22,6 @@
     "ark:/87293/d3ms3k62s",
     "D-592, Box:1 Folder:33"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_34.jsonld.json
+++ b/items/d592_34.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:34",
     "ark:/87293/d3h41jr9p"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_35.jsonld.json
+++ b/items/d592_35.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_35.tif"
   },
-  "schema:description": "\"Planted at the same time the mission was established. ventura - 20 ft. cut off in picture.\"",
+  "schema:description": "Planted at the same time the mission was established. ventura - 20 ft. cut off in picture.",
   "schema:identifier": [
     "ark:/87293/d3cc0tz5j",
     "AR-592, Box:1 Folder:35"

--- a/items/d592_35.jsonld.json
+++ b/items/d592_35.jsonld.json
@@ -23,9 +23,6 @@
     "ark:/87293/d3cc0tz5j",
     "AR-592, Box:1 Folder:35"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_36.jsonld.json
+++ b/items/d592_36.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:36",
     "ark:/87293/d37m0450q"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_37.jsonld.json
+++ b/items/d592_37.jsonld.json
@@ -22,9 +22,6 @@
     "ark:/87293/d33t9db6d",
     "AR-592, Box:1 Folder:37"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_38.jsonld.json
+++ b/items/d592_38.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:38",
     "ark:/87293/d3028pj32"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_39.jsonld.json
+++ b/items/d592_39.jsonld.json
@@ -23,9 +23,6 @@
     "ark:/87293/d3v97zw9j",
     "AR-592, Box:1 Folder:39"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_4.jsonld.json
+++ b/items/d592_4.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:4",
     "ark:/87293/d3416t43g"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_40.jsonld.json
+++ b/items/d592_40.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_40.tif"
   },
-  "schema:description": "Partial label on back: \"[R?]amona's marriage...[mi? Cale?]\"",
+  "schema:description": "Partial label on back: \"[R?]amona's marriage...[mi? Cale?]",
   "schema:identifier": [
     "ark:/87293/d3qj7834q",
     "AR-592, Box:1 Folder:40"

--- a/items/d592_40.jsonld.json
+++ b/items/d592_40.jsonld.json
@@ -23,9 +23,6 @@
     "ark:/87293/d3qj7834q",
     "AR-592, Box:1 Folder:40"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_41.jsonld.json
+++ b/items/d592_41.jsonld.json
@@ -23,9 +23,6 @@
     "ark:/87293/d3kw57p4c",
     "AR-592, Box:1 Folder:41"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_42.jsonld.json
+++ b/items/d592_42.jsonld.json
@@ -23,9 +23,6 @@
     "ark:/87293/d3g44hw0j",
     "AR-592, Box:1 Folder:42"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_43.jsonld.json
+++ b/items/d592_43.jsonld.json
@@ -23,9 +23,6 @@
     "AR-592, Box:1 Folder:43",
     "ark:/87293/d3bc3t25q"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_44.jsonld.json
+++ b/items/d592_44.jsonld.json
@@ -19,7 +19,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_44.tif"
   },
-  "schema:description": "\"Dashes are bees on the wing,\"",
+  "schema:description": "Dashes are bees on the wing,",
   "schema:identifier": [
     "AR-592, Box:1 Folder:44",
     "ark:/87293/d36m3381z"

--- a/items/d592_44.jsonld.json
+++ b/items/d592_44.jsonld.json
@@ -24,9 +24,6 @@
     "AR-592, Box:1 Folder:44",
     "ark:/87293/d36m3381z"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_45.jsonld.json
+++ b/items/d592_45.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:45",
     "ark:/87293/d32v2cf76"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_46.jsonld.json
+++ b/items/d592_46.jsonld.json
@@ -23,9 +23,6 @@
     "ark:/87293/d3z31nt3m",
     "AR-592, Box:1 Folder:46"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_46.jsonld.json
+++ b/items/d592_46.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_46.tif"
   },
-  "schema:description": "\"Donings (Ernest), cousin Maria Crane, Warren, Ruth, Cora Hardison, Helen.\"",
+  "schema:description": "Donings (Ernest), cousin Maria Crane, Warren, Ruth, Cora Hardison, Helen.",
   "schema:identifier": [
     "ark:/87293/d3z31nt3m",
     "AR-592, Box:1 Folder:46"

--- a/items/d592_47.jsonld.json
+++ b/items/d592_47.jsonld.json
@@ -22,9 +22,6 @@
     "ark:/87293/d3td9nd2n",
     "AR-592, Box:1 Folder:47"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_48.jsonld.json
+++ b/items/d592_48.jsonld.json
@@ -23,9 +23,6 @@
     "ark:/87293/d3pn8xk9c",
     "AR-592, Box:1 Folder:48"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_49.jsonld.json
+++ b/items/d592_49.jsonld.json
@@ -23,9 +23,6 @@
     "AR-592, Box:1 Folder:49",
     "ark:/87293/d3jw86s5m"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_5.jsonld.json
+++ b/items/d592_5.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:5",
     "ark:/87293/d30863993"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_50.jsonld.json
+++ b/items/d592_50.jsonld.json
@@ -22,9 +22,6 @@
     "ark:/87293/d3f47h00q",
     "AR-592, Box:1 Folder:50"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_51.jsonld.json
+++ b/items/d592_51.jsonld.json
@@ -22,9 +22,6 @@
     "ark:/87293/d39c6s56z",
     "AR-592, Box:1 Folder:51"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_52.jsonld.json
+++ b/items/d592_52.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:52",
     "ark:/87293/d35m62c26"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_53.jsonld.json
+++ b/items/d592_53.jsonld.json
@@ -23,9 +23,6 @@
     "AR-592, Box:1 Folder:53",
     "ark:/87293/d31v5bj8f"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_54.jsonld.json
+++ b/items/d592_54.jsonld.json
@@ -23,9 +23,6 @@
     "AR-592, Box:1 Folder:54",
     "ark:/87293/d3x63b963"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_54.jsonld.json
+++ b/items/d592_54.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_54.tif"
   },
-  "schema:description": "\"No relation.\"",
+  "schema:description": "No relation.",
   "schema:identifier": [
     "AR-592, Box:1 Folder:54",
     "ark:/87293/d3x63b963"

--- a/items/d592_55.jsonld.json
+++ b/items/d592_55.jsonld.json
@@ -22,9 +22,6 @@
     "ark:/87293/d3sf2mh1g",
     "AR-592, Box:1 Folder:55"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_56.jsonld.json
+++ b/items/d592_56.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:56",
     "ark:/87293/d3np1wp7q"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_57.jsonld.json
+++ b/items/d592_57.jsonld.json
@@ -22,9 +22,6 @@
     "AR-592, Box:1 Folder:57",
     "ark:/87293/d3hx15w2g"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_58.jsonld.json
+++ b/items/d592_58.jsonld.json
@@ -23,9 +23,6 @@
     "AR-592, Box:1 Folder:58",
     "ark:/87293/d3d50g28f"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_58.jsonld.json
+++ b/items/d592_58.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_58.tif"
   },
-  "schema:description": "\"Second mayor of Watsonville, California.\"",
+  "schema:description": "Second mayor of Watsonville, California.",
   "schema:identifier": [
     "AR-592, Box:1 Folder:58",
     "ark:/87293/d3d50g28f"

--- a/items/d592_59.jsonld.json
+++ b/items/d592_59.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_59.tif"
   },
-  "schema:description": "\"Winters, Calif.\"",
+  "schema:description": "Winters, Calif.",
   "schema:identifier": [
     "ark:/87293/d38c9r84r",
     "AR-592, Box:1 Folder:59"

--- a/items/d592_59.jsonld.json
+++ b/items/d592_59.jsonld.json
@@ -23,9 +23,6 @@
     "ark:/87293/d38c9r84r",
     "AR-592, Box:1 Folder:59"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_6.jsonld.json
+++ b/items/d592_6.jsonld.json
@@ -23,9 +23,6 @@
     "ark:/87293/d3vh5cp4q",
     "AR-592, Box:1 Folder:6"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_6.jsonld.json
+++ b/items/d592_6.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_6.tif"
   },
-  "schema:description": "\"Mother of Emer Gerber, Phoebe Gerber, Exra Gerber, Martha Gerber, Joel Gerber, Frank Gerber.\"",
+  "schema:description": "Mother of Emer Gerber, Phoebe Gerber, Exra Gerber, Martha Gerber, Joel Gerber, Frank Gerber.",
   "schema:identifier": [
     "ark:/87293/d3vh5cp4q",
     "AR-592, Box:1 Folder:6"

--- a/items/d592_60.jsonld.json
+++ b/items/d592_60.jsonld.json
@@ -23,9 +23,6 @@
     "AR-592, Box:1 Folder:60",
     "ark:/87293/d34m91g1g"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_7.jsonld.json
+++ b/items/d592_7.jsonld.json
@@ -23,9 +23,6 @@
     "AR-592, Box:1 Folder:7",
     "ark:/87293/d3qr4nw0k"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_7.jsonld.json
+++ b/items/d592_7.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_7.tif"
   },
-  "schema:description": "\"Wife of Benjamin Trafton. Children George Russell Trafton, Sarah [Mewton?] Trafton, Benjamin Augustus Trafton, James Gardner Trafton, John Reed Trafton.\"",
+  "schema:description": "Wife of Benjamin Trafton. Children George Russell Trafton, Sarah [Mewton?] Trafton, Benjamin Augustus Trafton, James Gardner Trafton, John Reed Trafton.",
   "schema:identifier": [
     "AR-592, Box:1 Folder:7",
     "ark:/87293/d3qr4nw0k"

--- a/items/d592_8.jsonld.json
+++ b/items/d592_8.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_8.tif"
   },
-  "schema:description": "\"Son of George W. Trafton\"",
+  "schema:description": "Son of George W. Trafton",
   "schema:identifier": [
     "ark:/87293/d3m03z26j",
     "AR-592, Box:1 Folder:8"

--- a/items/d592_8.jsonld.json
+++ b/items/d592_8.jsonld.json
@@ -23,9 +23,6 @@
     "ark:/87293/d3m03z26j",
     "AR-592, Box:1 Folder:8"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },

--- a/items/d592_9.jsonld.json
+++ b/items/d592_9.jsonld.json
@@ -18,7 +18,7 @@
   "schema:associatedMedia": {
     "@id": "@base:/d592_9.tif"
   },
-  "schema:description": "\"Adah G. Trafton, his wife. One son William Mason Trafton.\"",
+  "schema:description": "Adah G. Trafton, his wife. One son William Mason Trafton.",
   "schema:identifier": [
     "ark:/87293/d3g73782s",
     "AR-592, Box:1 Folder:9"

--- a/items/d592_9.jsonld.json
+++ b/items/d592_9.jsonld.json
@@ -23,9 +23,6 @@
     "ark:/87293/d3g73782s",
     "AR-592, Box:1 Folder:9"
   ],
-  "schema:isPartOf": {
-    "@id": "https://oac.cdlib.org/findaid/ark:/13030/c8b56p4p/"
-  },
   "schema:license": {
     "@id": "http://rightsstatements.org/vocab/NoC-US/1.0/"
   },


### PR DESCRIPTION
Fixed with 

```bash
for i in items/*.json; do 
  cp $i tmp.json; jq 'del(.["schema:isPartOf"])' tmp.json > $i ; 
done
```

and 

``` bash
for i in items/*.json; do 
  cp $i tmp.json; sed -e 's/"\\"/"/' -e 's/\\""/"/'  tmp.json > $i ; 
done
```